### PR TITLE
해시태그 검색 페이지와 관련 기능 구현

### DIFF
--- a/src/main/java/com/jycproject/bulletinboard/controller/ArticleController.java
+++ b/src/main/java/com/jycproject/bulletinboard/controller/ArticleController.java
@@ -44,7 +44,7 @@ public class ArticleController {
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),articles.getTotalPages());
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers",barNumbers);
-        map.addAttribute("searchTypes",searchType.values());
+        map.addAttribute("searchTypes",SearchType.values());
 
         return "articles/index";
     }
@@ -56,6 +56,23 @@ public class ArticleController {
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount",articleService.getArticleCount());
         return "articles/detail";
+    }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort ="createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+        ) {
+        Page<ArticleResponse> articles =  articleService.searchArticlesViaHashtag(searchValue,pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers",barNumbers);
+        map.addAttribute("searchType",SearchType.HASHTAG);
+
+        return"articles/search-hashtag";
     }
 
 }

--- a/src/main/java/com/jycproject/bulletinboard/repository/ArticleRepository.java
+++ b/src/main/java/com/jycproject/bulletinboard/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.jycproject.bulletinboard.repository;
 
 import com.jycproject.bulletinboard.domain.Article;
 import com.jycproject.bulletinboard.domain.QArticle;
+import com.jycproject.bulletinboard.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle> {
     Page<Article> findByTitleContaining(String title, Pageable pageable);

--- a/src/main/java/com/jycproject/bulletinboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/jycproject/bulletinboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.jycproject.bulletinboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/src/main/java/com/jycproject/bulletinboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/jycproject/bulletinboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package com.jycproject.bulletinboard.repository.querydsl;
+
+import com.jycproject.bulletinboard.domain.Article;
+import com.jycproject.bulletinboard.domain.QArticle;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+        JPQLQuery<String> query = from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull());
+
+        return query.fetch();
+
+    }
+}

--- a/src/main/java/com/jycproject/bulletinboard/service/ArticleService.java
+++ b/src/main/java/com/jycproject/bulletinboard/service/ArticleService.java
@@ -78,5 +78,15 @@ public class ArticleService {
         return articleRepository.count();
     }
 
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if (hashtag == null || hashtag.isBlank()){
+            return Page.empty(pageable);
+        }
+        return articleRepository.findByHashtag(hashtag,pageable).map(ArticleDto::from);
+    }
 
+    public List<String> getHashtags() {
+       return articleRepository.findAllDistinctHashtags();
+    }
 }

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -42,7 +42,7 @@
 
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
-                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/ + ${article.id}}"/>
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
                     <attr sel="td.hashtag" th:text="${article.hashtag}"/>
                     <attr sel="td.user-id" th:text="${article.nickname}"/>
                     <attr sel="td.created-at/time" th:datetime="${article.createdAt}"

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -1,11 +1,86 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
-
-    <title>Articles</title>
+    <title>해시태그 검색</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="author" content="YeongChan Jeong">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/articles/table-header.css">
 </head>
 <body>
-    게시글 해시태그 검색
+
+<header id="header">
+    헤더 삽입부
+    <hr>
+</header>
+<main class="container">
+    <header class="py-5 text-center">
+        <h1>Hashtags</h1>
+    </header>
+
+    <section class="row d-flex justify-content-center">
+        <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+            <div class="p-2">
+                <h2 class="text-center 1h-lg font-monospace"><a href="#">#java</a></h2>
+            </div>
+        </div>
+    </section>
+    <table class="table" id="article-table">
+        <thead>
+        <tr>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="content col-4"><a>본문</a></th>
+            <th class="user-id"><a>작성자</a></th>
+            <th class="created-at"><a>작성일</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="title"><a>첫글</a></td>
+            <td class="content"><span class="d-inline-block text-truncate" style="max-width:300px;">본문</span></td>
+            <td class="user-id">Jyc</td>
+            <td class="created-at">
+                <time>2022-01-01</time>
+            </td>
+        </tr>
+        <tr>
+            <td>두번째글</td>
+            <td>#spring</td>
+            <td>Uno</td>
+            <td>
+                <time>2022-01-02</time>
+            </td>
+        </tr>
+        <tr>
+            <td>세번째글</td>
+            <td>#java</td>
+            <td>Uno</td>
+            <td>
+                <time>2022-01-03</time>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+
+    <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+    </nav>
+
+
+</main>
+<footer id="footer">
+    <hr>
+    푸터 삽입부
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+        crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<thlogic xmlns:th="http://www.thymeleaf.org">
+    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#footer" th:replace="footer :: footer"/>
+    <attr sel="main" th:object="${articles}">
+
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+                    page=${param.page},
+                    sort=${param.sort},
+                    searchType=${searchType.name},
+                    searchValue=${hashtag}
+                )}"/>
+            </attr>
+        </attr>
+
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="제목" th:href="@{/articles/search-hashtag(
+                page=${articles.number},
+                sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                searchType=${searchType.name},
+                searchValue=${param.searchValue}
+                )}"/>
+                <attr sel="th.content/a" th:text="본문" th:href="@{/articles/search-hashtag(
+                page=${articles.number},
+                sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                searchType=${searchType.name},
+                searchValue=${param.searchValue}
+                )}"/>
+                <attr sel="th.user-id/a" th:text="작성자" th:href="@{/articles/search-hashtag(
+                page=${articles.number},
+                sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                searchType=${searchType.name},
+                searchValue=${param.searchValue}
+                )}"/>
+                <attr sel="th.created-at/a" th:text="작성일" th:href="@{/articles/search-hashtag(
+                page=${articles.number},
+                sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                searchType=${searchType.name},
+                searchValue=${param.searchValue}
+                )}"/>
+            </attr>
+
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
+                    <attr sel="td.content/span" th:text="${article.content}"/>
+                    <attr sel="td.user-id" th:text="${article.nickname}"/>
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}"
+                          th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
+                </attr>
+            </attr>
+        </attr>
+        <attr sel="#pagination">
+            <attr sel="li[0]/a"
+                  th:text="'previous'"
+                  th:href="@{/articles/search-hashtag(page=${articles.number - 1},searchType=${searchType.name},searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '' )"
+            />
+            <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                <attr sel="a"
+                      th:text="${pageNumber + 1}"
+                      th:href="@{/articles/search-hashtag(page=${pageNumber},searchType=${searchType.name},searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                />
+            </attr>
+            <attr sel="li[2]/a"
+                  th:text="'next'"
+                  th:href="@{/articles/search-hashtag(page=${articles.number + 1},searchType=${searchType.name},searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages -1} ? ' disabled' : '')"
+            />
+
+        </attr>
+
+    </attr>
+</thlogic>

--- a/src/test/java/com/jycproject/bulletinboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jycproject/bulletinboard/controller/ArticleControllerTest.java
@@ -147,17 +147,51 @@ class ArticleControllerTest {
                 .andExpect(result -> content().contentType(MediaType.TEXT_HTML)) // 데이터 확인
                 .andExpect(view().name("articles/search")); // 뷰의 존재여부 검사
     }
-    @Disabled("구현 중")
     @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
     @Test
-    public void givenNothing_whenRequestingArticleHashtagSearchView_thenReturnsArticleHashtagSearchView() throws Exception {
+    public void givenNothing_whenRequestingArticleSearchHashtagView_thenReturnsArticleSearchHashtagView() throws Exception {
         // Given
-
+        List<String> hashtags = List.of("#java","#spring","boot");
+        given(articleService.searchArticlesViaHashtag(eq(null),any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(1,2,3,4,5));
+        given(articleService.getHashtags()).willReturn(hashtags);
         // When & Then
         mvc.perform(get("/articles/search-hashtag"))
                 .andExpect(status().isOk()) // 정상 호출
                 .andExpect(result -> content().contentType(MediaType.TEXT_HTML)) // 데이터 확인
-                .andExpect(view().name("articles/search-hashtag")); // 뷰의 존재여부 검사
+                .andExpect(view().name("articles/search-hashtag")) // 뷰의 존재여부 검사
+                .andExpect(model().attribute("articles",Page.empty()))
+                .andExpect(model().attribute("hashtags",hashtags))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attribute("searchType",SearchType.HASHTAG));
+        then(articleService).should().searchArticlesViaHashtag(eq(null),any(Pageable.class));
+        then(articleService).should().getHashtags();
+        then(paginationService).should().getPaginationBarNumbers(anyInt(),anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출, 해시태그 입력")
+    @Test
+    public void givenHashtag_whenRequestingArticleSearchHashtagView_thenReturnsArticleSearchHashtagView() throws Exception {
+        // Given
+        String hashtag = "#java";
+        List<String> hashtags = List.of("#java","#spring","boot");
+        given(articleService.searchArticlesViaHashtag(eq(hashtag),any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(1,2,3,4,5));
+        given(articleService.getHashtags()).willReturn(hashtags);
+        // When & Then
+        mvc.perform(get("/articles/search-hashtag")
+                        .queryParam("searchValue",hashtag)
+                )
+                .andExpect(status().isOk()) // 정상 호출
+                .andExpect(result -> content().contentType(MediaType.TEXT_HTML)) // 데이터 확인
+                .andExpect(view().name("articles/search-hashtag")) // 뷰의 존재여부 검사
+                .andExpect(model().attribute("articles",Page.empty()))
+                .andExpect(model().attribute("hashtags",hashtags))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attribute("searchType",SearchType.HASHTAG));
+        then(articleService).should().searchArticlesViaHashtag(eq(hashtag),any(Pageable.class));
+        then(articleService).should().getHashtags();
+        then(paginationService).should().getPaginationBarNumbers(anyInt(),anyInt());
     }
 
     private ArticleWithCommentsDto createArticleCommentsDto() {

--- a/src/test/java/com/jycproject/bulletinboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/jycproject/bulletinboard/service/ArticleServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import javax.persistence.EntityNotFoundException;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -67,6 +68,34 @@ class ArticleServiceTest {
         // Then
         assertThat(articles).isEmpty();
         then(articleRepository).should().findByTitleContaining(searchKeyword,pageable);
+    }
+
+    @DisplayName("검색어 없이 게시글을 해시태그로 검색하면, 빈 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticlesViaHashtag_thenReturnsEmptyPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(null,pageable);
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글을 해시태그로 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenHashtag_whenSearchingArticlesViaHashtag_thenReturnsArticlesPage() {
+        // Given
+        String hashtag = "#java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtag,pageable);
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag,pageable);
     }
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
@@ -173,6 +202,21 @@ class ArticleServiceTest {
 
        assertThat(actual).isEqualTo(expected);
        then(articleRepository).should().count();
+    }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsHashTags(){
+        // Given
+       List<String> expectedHashtags = List.of("#java","#spring","#boot");
+       given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtags);
+
+        // When
+        List<String> actualHashtags = sut.getHashtags();
+        // Then
+
+        assertThat(actualHashtags).isEqualTo(expectedHashtags);
+        then(articleRepository).should().findAllDistinctHashtags();
     }
 
 


### PR DESCRIPTION
해시태그 페이지와 관련 기능 구현

* 해시태그를 통해 검색을 하는 페이지를 따로 만들기 위해서 해당 페이지의 기능 테스트작성
     * 검색어 없이 검색할 경우, 빈 페이지 반환 여부
     * 해시태그로 검색하면, 게시글 페이지 반환 여부
     * 전체 게시글이 보유한 해시태그를 리스트로 반환 여부
* 전체 게시글이 보유한 해시태그를 반환하기 위해서 `querydsl`을 사용해서 쿼리 출력결과가 문자열로 나타나게 함 

* 테스트에 맞게 서비스를 구현함
* 서비스를 사용해서 컨트롤러 구현함
* 이 과정에서 이전에 `disabled`한 테스트 중 하나인 게시글 해시태그 검색 페이지 정상 호출 테스트도 구현함 
* 테스트 추가 - 게시글 해시태그 검색페이지 - 정상 호출, 해시태그 입력한 경우


* 해시태그 검색페이지를 구현했고, 디커플드 로직 파일로 기능 부여하여 페이지 완성(검색 결과 표시 및 정렬,페이징 기능 모두 오류없이 동작함)
* 이 과정에서 게시글 페이지가 들어가지지않는 오류를 인지하여 해결함
     * 디커플드 로직 파일(`index.th.xml`,`search-hashtag.th.xml`에서 게시글 제목의 `href`에서 부호를 하나 덜 찍어서 `${article.id}`의 값이 이상하게 지정되어 오류가 발생했기 때문에 이를 수정했음
This closes #37 