### PR TITLE
헤더에 해시태그 메뉴 추가 및, Home 메뉴 경로 설정

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -13,7 +13,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtag</a></li>
             </ul>
 
             <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic xmlns:th="http://www.thymeleaf.org">
+    <attr sel="#home" th:href="@{/}"/>
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}"/>
+</thlogic>


### PR DESCRIPTION
* 해시태그 검색페이지를 이용하기 쉽게 헤더에 `Hashtag`메뉴를 추가해서 클릭하면 검색페이지로 이동할 수 있게 url을 설정함
* 초기에 제작한 Home 메뉴의 url이 설정되지 않아서 url 게시판페이지로 설정함