### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-)implements Serializable {
+) {
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
     }

--- a/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+){
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);
     }

--- a/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleWithCommentsResponse.java
@@ -18,7 +18,7 @@ public record ArticleWithCommentsResponse(
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
 
-) implements Serializable {
+){
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponse) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponse);


### PR DESCRIPTION
JPA Buddy를 이용해 작성한 DTO인데, 자동으로 implements Serializable이 들어가버림
현재 프로젝트에서는 직렬화로  Jackson을 사용하므로 필요하지 않고, 의도해서 넣은 것도 아니므로 제거함