### PR TITLE
엔티티 equals() 수정

### DIFF
--- a/src/main/java/com/jycproject/bulletinboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/jycproject/bulletinboard/controller/ArticleCommentController.java
@@ -21,7 +21,7 @@ public class ArticleCommentController {
     @PostMapping("/new")
     public String postNewArticleComment(ArticleCommentRequest articleCommentRequest,
                                         @AuthenticationPrincipal BoardPrincipal boardPrincipal
-                                        ) {
+    ) {
         articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
@@ -30,11 +30,11 @@ public class ArticleCommentController {
     public String deleteArticleComment(@PathVariable Long commentId,
                                        Long articleId,
                                        @AuthenticationPrincipal BoardPrincipal boardPrincipal
-    ){
+    ) {
         articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
 
 
-        return "redirect:/articles/" + articleId ;
+        return "redirect:/articles/" + articleId;
     }
 
 }

--- a/src/main/java/com/jycproject/bulletinboard/controller/ArticleController.java
+++ b/src/main/java/com/jycproject/bulletinboard/controller/ArticleController.java
@@ -40,13 +40,13 @@ public class ArticleController {
     public String articles(
             @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchValue,
-            @PageableDefault(size = 10, sort ="createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map) {
-        Page<ArticleResponse> articles =  articleService.searchArticles(searchType,searchValue,pageable).map(ArticleResponse::from);
-        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),articles.getTotalPages());
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         map.addAttribute("articles", articles);
-        map.addAttribute("paginationBarNumbers",barNumbers);
-        map.addAttribute("searchTypes",SearchType.values());
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
 
         return "articles/index";
     }
@@ -56,25 +56,25 @@ public class ArticleController {
         ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticleWithComments(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
-        map.addAttribute("totalCount",articleService.getArticleCount());
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
 
     @GetMapping("/search-hashtag")
     public String searchArticleHashtag(
             @RequestParam(required = false) String searchValue,
-            @PageableDefault(size = 10, sort ="createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
-        ) {
-        Page<ArticleResponse> articles =  articleService.searchArticlesViaHashtag(searchValue,pageable).map(ArticleResponse::from);
-        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),articles.getTotalPages());
+    ) {
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         List<String> hashtags = articleService.getHashtags();
         map.addAttribute("articles", articles);
         map.addAttribute("hashtags", hashtags);
-        map.addAttribute("paginationBarNumbers",barNumbers);
-        map.addAttribute("searchType",SearchType.HASHTAG);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
 
-        return"articles/search-hashtag";
+        return "articles/search-hashtag";
     }
 
 
@@ -88,7 +88,7 @@ public class ArticleController {
     @PostMapping("/form")
     public String postNewArticle(ArticleRequest articleRequest,
                                  @AuthenticationPrincipal BoardPrincipal boardPrincipal
-    ){
+    ) {
 
         articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles";
@@ -98,7 +98,7 @@ public class ArticleController {
     public String updateArticleForm(@PathVariable Long articleId, ModelMap map) {
         ArticleResponse article = ArticleResponse.from(articleService.getArticle(articleId));
 
-        map.addAttribute("article",article);
+        map.addAttribute("article", article);
         map.addAttribute("formStatus", FormStatus.UPDATE);
 
         return "articles/form";
@@ -108,15 +108,15 @@ public class ArticleController {
     public String updateArticle(@PathVariable Long articleId,
                                 ArticleRequest articleRequest,
                                 @AuthenticationPrincipal BoardPrincipal boardPrincipal
-    ){
-        articleService.updateArticle(articleId,articleRequest.toDto(boardPrincipal.toDto()));
+    ) {
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping("/{articleId}/delete")
     public String deleteArticle(@PathVariable Long articleId,
                                 @AuthenticationPrincipal BoardPrincipal boardPrincipal
-    ){
+    ) {
 
 
         articleService.deleteArticle(articleId, boardPrincipal.getUsername());

--- a/src/main/java/com/jycproject/bulletinboard/domain/Article.java
+++ b/src/main/java/com/jycproject/bulletinboard/domain/Article.java
@@ -65,8 +65,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article) ) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that) ) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/jycproject/bulletinboard/domain/ArticleComment.java
+++ b/src/main/java/com/jycproject/bulletinboard/domain/ArticleComment.java
@@ -53,7 +53,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/jycproject/bulletinboard/domain/UserAccount.java
+++ b/src/main/java/com/jycproject/bulletinboard/domain/UserAccount.java
@@ -43,7 +43,7 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.userId);
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override

--- a/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/jycproject/bulletinboard/dto/response/ArticleCommentResponse.java
@@ -13,12 +13,13 @@ public record ArticleCommentResponse(
         String nickname,
         String userId
 ) {
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname,String userId) {
-       return new ArticleCommentResponse(id, content, createdAt, email, nickname,userId);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
-    public static ArticleCommentResponse from(ArticleCommentDto dto){
+
+    public static ArticleCommentResponse from(ArticleCommentDto dto) {
         String nickname = dto.userAccountDto().nickname();
-        if(nickname == null || nickname.isBlank()){
+        if (nickname == null || nickname.isBlank()) {
             nickname = dto.userAccountDto().userId();
         }
 

--- a/src/main/java/com/jycproject/bulletinboard/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/jycproject/bulletinboard/dto/security/BoardPrincipal.java
@@ -17,22 +17,22 @@ public record BoardPrincipal(
         String email,
         String nickname,
         String memo
-)  implements UserDetails {
+) implements UserDetails {
 
 
     public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
         Set<RoleType> roleTypes = Set.of(RoleType.USER);
-       return new BoardPrincipal(
-               username,
-               password,
-               roleTypes.stream()
-                       .map(RoleType::getName)
-                       .map(SimpleGrantedAuthority::new)
-                       .collect(Collectors.toUnmodifiableSet()),
-               email,
-               nickname,
-               memo
-       );
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
     }
 
     public static BoardPrincipal from(UserAccountDto dto) {
@@ -56,15 +56,20 @@ public record BoardPrincipal(
     }
 
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+    public String getUsername() {
+        return username;
+    }
 
     @Override
-    public String getUsername() { return username; }
-
-    @Override
-    public String getPassword() { return password; }
+    public String getPassword() {
+        return password;
+    }
 
     @Override
     public boolean isAccountNonExpired() {
@@ -86,14 +91,14 @@ public record BoardPrincipal(
         return true;
     }
 
-    public enum RoleType{
+    public enum RoleType {
         USER("ROLE_USER");
 
         @Getter
         private final String name;
 
         RoleType(String name) {
-            this.name  = name;
+            this.name = name;
         }
     }
 }

--- a/src/main/java/com/jycproject/bulletinboard/service/ArticleService.java
+++ b/src/main/java/com/jycproject/bulletinboard/service/ArticleService.java
@@ -35,8 +35,10 @@ public class ArticleService {
         return switch (searchType) {
             case TITLE -> articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
             case CONTENT -> articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case ID -> articleRepository.findByUserAccount_UserIdContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case NICKNAME -> articleRepository.findByUserAccount_NicknameContaining(searchKeyword, pageable).map(ArticleDto::from);
+            case ID ->
+                    articleRepository.findByUserAccount_UserIdContaining(searchKeyword, pageable).map(ArticleDto::from);
+            case NICKNAME ->
+                    articleRepository.findByUserAccount_NicknameContaining(searchKeyword, pageable).map(ArticleDto::from);
             case HASHTAG -> articleRepository.findByHashtag("#" + searchKeyword, pageable).map(ArticleDto::from);
         };
     }
@@ -66,8 +68,12 @@ public class ArticleService {
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
             if (article.getUserAccount().equals(userAccount)) {
-                if (dto.title() != null) { article.setTitle(dto.title()); }
-                if (dto.content() != null) { article.setContent(dto.content()); }
+                if (dto.title() != null) {
+                    article.setTitle(dto.title());
+                }
+                if (dto.content() != null) {
+                    article.setContent(dto.content());
+                }
                 article.setHashtag(dto.hashtag());
             }
         } catch (EntityNotFoundException e) {


### PR DESCRIPTION
게시판 수정기능이 제대로 동작하지 않아서 코드를 살펴본 결과 `that.id`같은 표현이 의도치 않은 동작을 만들게 되어서
수정 작업이 제대로 이루어지지 않은 것으로 확인되었다. 
따라서 제대로 `getter`를 써서 값을 불러오게 수정함
이름도 `that`으로 통일시켰다.