### PR TITLE
헤로쿠에 배포하기 - 헤로쿠 DB 변경: ClearDB -> jawsDB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
조사해본 결과, cleardb의 기본 mysql버전이 `5.6`으로 너무 낮기 때문에 문제가 발생함(`article_comment.content`인덱스 사이즈가 너무 큼)
대안으로  jawsdb를 찾아냄 
기본 mysql 버전 `8.0`
이를 이용해 환경변수를 다시 작업함
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup
* https://devcenter.heroku.com/articles/jawsdb
